### PR TITLE
Fix home navigation and dynamic difficulty text

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>IELTS Master - Practice Tests & Study Plans</title>
+  <title>English Master - Vocabulary Games</title>
 </head>
 
 <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "eslint-plugin-react": "^7.35.0",
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
         "eslint-plugin-react-refresh": "^0.4.9",
+        "globals": "^16.2.0",
         "postcss": "^8.4.45",
         "tailwindcss": "^3.4.10",
         "typescript": "^5.3.3",
@@ -3677,6 +3678,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globals": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.2.0.tgz",
+      "integrity": "sha512-O+7l9tPdHCU320IigZZPj5zmRCFG9xHmx9cU8FqU2Rp+JN714seHV+2S9+JslCpY4gJwU2vOGox0wzgae/MCEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globalthis": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.9",
+    "globals": "^16.2.0",
     "postcss": "^8.4.45",
     "tailwindcss": "^3.4.10",
     "typescript": "^5.3.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import MatchingCardsGame from './components/MatchingCardsGame';
 import { useTheme } from './hooks/useTheme';
 
 const App: React.FC = () => {
   const { theme, toggleTheme } = useTheme();
+  const [view, setView] = useState<'home' | 'matching'>('home');
+
   return (
     <div className={theme === 'dark' ? 'dark' : ''}>
       <div className="min-h-screen bg-[rgb(var(--color-surface))] text-[rgb(var(--color-text))] transition-colors duration-300 p-4">
@@ -12,7 +14,20 @@ const App: React.FC = () => {
             Toggle Theme
           </button>
         </div>
-        <MatchingCardsGame onBack={() => {}} />
+
+        {view === 'home' ? (
+          <div className="flex flex-col items-center justify-center gap-4 mt-20">
+            <h1 className="text-3xl font-bold">English Games</h1>
+            <button
+              onClick={() => setView('matching')}
+              className="btn-primary rounded px-4 py-2"
+            >
+              Play Matching Cards
+            </button>
+          </div>
+        ) : (
+          <MatchingCardsGame onBack={() => setView('home')} />
+        )}
       </div>
     </div>
   );

--- a/src/components/MatchingCardsGame.tsx
+++ b/src/components/MatchingCardsGame.tsx
@@ -256,9 +256,9 @@ const MatchingCardsGame: React.FC<MatchingCardsGameProps> = ({ onBack }) => {
                   {level}
                 </h3>
                 <div className="text-sm text-gray-600 dark:text-gray-400 mb-4">
-                  {level === 'easy' && '6 pairs • Basic vocabulary'}
-                  {level === 'medium' && '8 pairs • Intermediate words'}
-                  {level === 'hard' && '10 pairs • Advanced vocabulary'}
+                  {level === 'easy' && `${vocabularyPairs[level].length} pairs • Basic vocabulary`}
+                  {level === 'medium' && `${vocabularyPairs[level].length} pairs • Intermediate words`}
+                  {level === 'hard' && `${vocabularyPairs[level].length} pairs • Advanced vocabulary`}
                 </div>
                 <Button className="w-full">
                   <Play className="w-4 h-4 mr-2" />
@@ -444,7 +444,7 @@ const MatchingCardsGame: React.FC<MatchingCardsGameProps> = ({ onBack }) => {
                     <CardContent className="h-full flex items-center justify-center p-2">
                       <div className="text-white text-center">
                         <Target className="w-8 h-8 mx-auto mb-2" />
-                        <div className="text-xs font-medium">IELTS</div>
+                        <div className="text-xs font-medium">English</div>
                       </div>
                     </CardContent>
                   </Card>


### PR DESCRIPTION
## Summary
- add a simple home screen in `App` so Back buttons work
- show pair counts from data instead of hard coded text
- change IELTS references to a generic English theme
- update project title
- add `globals` as a dev dependency so ESLint runs

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857f4cd0bb883309b42c8d28ce5c196